### PR TITLE
add module export plugin, add babel-polyfill to dependencies

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": ["es2015", "stage-0"],
-  "plugins": ["syntax-async-functions", "transform-regenerator"]
+  "plugins": ["syntax-async-functions", "transform-regenerator", "add-module-exports"]
 }
 

--- a/package.json
+++ b/package.json
@@ -29,14 +29,15 @@
   "dependencies": {
     "async-file": "^2.0.2",
     "axios": "^0.15.3",
+    "babel-polyfill": "^6.23.0",
     "moment": "^2.17.1"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-core": "^6.23.1",
+    "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-syntax-async-functions": "^6.13.0",
     "babel-plugin-transform-regenerator": "^6.22.0",
-    "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "babel-preset-stage-0": "^6.22.0",
     "chai": "^3.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -341,6 +341,10 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
+babel-plugin-add-module-exports@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-exports/-/babel-plugin-add-module-exports-0.2.1.tgz#9ae9a1f4a8dc67f0cdec4f4aeda1e43a5ff65e25"
+
 babel-plugin-check-es2015-constants@^6.22.0:
   version "6.22.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"


### PR DESCRIPTION
Unable to install package from npm:

1. `babel-polyfill` not found
2. Crash for non-ES7 syntax
```js
var NaughtyChecker = require('NaughtyChecker');
var nc = new NaughtyChecker();

var fromOnline = function () {
  var result = nc.validate('naughty string').then(function (result) {
    console.log('ok');
  }).catch(function (error) {
    console.log('error');
  })
};
```

This PR fixed the above issues